### PR TITLE
fix: use /health endpoint for health checks

### DIFF
--- a/k8s/deployment.yaml
+++ b/k8s/deployment.yaml
@@ -34,7 +34,7 @@ spec:
             cpu: "500m"
         livenessProbe:
           httpGet:
-            path: /docs
+            path: /health
             port: 8000
           initialDelaySeconds: 30
           periodSeconds: 10
@@ -44,7 +44,7 @@ spec:
               command: ["sh", "-c", "sleep 5"]
         readinessProbe:
           httpGet:
-            path: /docs
+            path: /health
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 5

--- a/k8s/staging-backend-deployment.yaml
+++ b/k8s/staging-backend-deployment.yaml
@@ -34,7 +34,7 @@ spec:
             cpu: "500m"
         livenessProbe:
           httpGet:
-            path: /docs
+            path: /health
             port: 8000
           initialDelaySeconds: 30
           periodSeconds: 10
@@ -44,7 +44,7 @@ spec:
               command: ["sh", "-c", "sleep 5"]
         readinessProbe:
           httpGet:
-            path: /docs
+            path: /health
             port: 8000
           initialDelaySeconds: 5
           periodSeconds: 5


### PR DESCRIPTION
Using the /docs endpoint for health checks can cause delays and lead to the "Does not have minimum availability" error. This commit updates the liveness and readiness probes to use the dedicated /health endpoint, which is lightweight and provides a faster response.